### PR TITLE
Enable undo for layer deletion

### DIFF
--- a/script.js
+++ b/script.js
@@ -903,6 +903,7 @@ function updateLayerRotation() {
 
 function deleteLayer() {
   if (selectedLayer === -1) return;
+  saveState();
   layers.splice(selectedLayer, 1);
   selectedLayer = -1;
   updateLayerControls();


### PR DESCRIPTION
## Summary
- Save canvas state before deleting a layer so layer removal can be undone

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b959dc21c0832cafd7983e32b2cae7